### PR TITLE
Fixed accidental text in settings.py

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -12,7 +12,7 @@ DATA_DIR = BASE_DIR / "Data"
 FILES_DIR = FRONTEND_DIR / "Files"
 GRAPHICS_DIR = FRONTEND_DIR / "Graphics"
 
-fix/add-missing-config-defaults-60
+#fix/add-missing-config-defaults-60
 # Chat/logging defaults
 CHAT_LOG_PATH = FILES_DIR / "chat_log.json"
 
@@ -31,4 +31,4 @@ DATA_DIR.mkdir(exist_ok=True)
 PRODUCTIVITY_DIR.mkdir(exist_ok=True)
 FILES_DIR.mkdir(exist_ok=True)
 GRAPHICS_DIR.mkdir(exist_ok=True)
-main
+#main


### PR DESCRIPTION
## Description

Removed accidental stray text from `config/settings.py` that was causing runtime errors during startup.

### Fixed Issues

* Removed unintended line:

  ```python
  fix/add-missing-config-defaults-60
  ```
* Removed stray `main` text from the file.

### Result

The application proceeds further during startup without raising:

```python
NameError: name 'fix' is not defined
```


## GSSOC 26'
- [x] **I am a contributor for GirlScript Summer Of Code 26'**

---
*By submitting this PR, I agree to maintain the high technical standards of the VYOM project.*
